### PR TITLE
fix: incorrect min PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "ext-curl" : "*"
     },
     "require-dev": {


### PR DESCRIPTION
Bumped from ^7.0 to ^7.1 as at least one feature from 7.1 is in use.